### PR TITLE
Implement ISuggestedAction directly

### DIFF
--- a/HtmlExtensions/Actions/BaseHtmlLightBulbAction.cs
+++ b/HtmlExtensions/Actions/BaseHtmlLightBulbAction.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Html.Core.Tree.Nodes;
-using Microsoft.Html.Editor.SuggestedActions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 

--- a/HtmlExtensions/Actions/HtmlSuggestedActionBase.cs
+++ b/HtmlExtensions/Actions/HtmlSuggestedActionBase.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Html.Core.Tree.Nodes;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace VSCustomElement.HtmlExtensions
+{
+    internal abstract class HtmlSuggestedActionBase : SuggestedActionBase
+    {
+        public ElementNode Element { get; private set; }
+
+        public AttributeNode Attribute { get; private set; }
+
+        protected HtmlSuggestedActionBase(ITextView textView, ITextBuffer textBuffer, ElementNode element, string displayText)
+            : this(textView, textBuffer, element, null, displayText)
+        {
+        }
+
+        protected HtmlSuggestedActionBase(ITextView textView, ITextBuffer textBuffer, ElementNode element, AttributeNode attribute, string displayText)
+            : base(textBuffer, textView, displayText)
+        {
+            Element = element;
+            Attribute = attribute;
+        }
+    }
+}

--- a/HtmlExtensions/Actions/SuggestedActionBase.cs
+++ b/HtmlExtensions/Actions/SuggestedActionBase.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace VSCustomElement.HtmlExtensions
+{
+    /// <summary>
+    /// Base class for suggested action implementations.  Actions can derive from this type and specialize as necessary for their appropriate
+    /// language context (e.g. HTML, JSON, etc).
+    /// </summary>
+    public abstract class SuggestedActionBase : ISuggestedAction
+    {
+        public SuggestedActionBase(ITextBuffer buffer, ITextView view, string displayText)
+        {
+            TextBuffer = buffer;
+            TextView = view;
+            DisplayText = displayText;
+        }
+
+        public ITextBuffer TextBuffer
+        {
+            get;
+            private set;
+        }
+
+        public ITextView TextView
+        {
+            get;
+            private set;
+        }
+
+        #region ISuggestedAction members
+
+        /// <summary>
+        /// By default, nested actions are not supported.
+        /// </summary>
+        public virtual bool HasActionSets
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// By default, nested actions are not supported.
+        /// </summary>
+        public virtual Task<IEnumerable<SuggestedActionSet>> GetActionSetsAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<SuggestedActionSet>>(null);
+        }
+
+        public string DisplayText
+        {
+            get;
+            private set;
+        }
+
+        public string IconAutomationText
+        {
+            get;
+            protected set;
+        }
+
+        public ImageMoniker IconMoniker
+        {
+            get;
+            protected set;
+        }
+
+        public string InputGestureText
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// By default, Preview is not supported.
+        /// </summary>
+        public virtual bool HasPreview
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// By default, Preview is not supported.
+        /// </summary>
+        public virtual Task<object> GetPreviewAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<object>(null);
+        }
+
+        public abstract void Invoke(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// By default, telemetry is not supported.
+        /// </summary>
+        public virtual bool TryGetTelemetryId(out Guid telemetryId)
+        {
+            telemetryId = Guid.Empty;
+            return false;
+        }
+
+        #region IDisposable Support
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
+
+        #endregion
+    }
+}

--- a/VSCustomElement.csproj
+++ b/VSCustomElement.csproj
@@ -44,8 +44,10 @@
     <Compile Include="CommandConstants.cs" />
     <Compile Include="Helpers\HtmlHelper.cs" />
     <Compile Include="HtmlExtensions\Actions\BaseHtmlLightBulbAction.cs" />
+    <Compile Include="HtmlExtensions\Actions\HtmlSuggestedActionBase.cs" />
     <Compile Include="HtmlExtensions\Actions\RememberAttributeLightBulbAction.cs" />
     <Compile Include="HtmlExtensions\Actions\RememberGlobalAttributeLightBulbAction.cs" />
+    <Compile Include="HtmlExtensions\Actions\SuggestedActionBase.cs" />
     <Compile Include="HtmlExtensions\Providers\BaseHtmlLightBulbProvider.cs" />
     <Compile Include="HtmlExtensions\Providers\RememberAttributeLightBulbProvider.cs" />
     <Compile Include="HtmlExtensions\Providers\RememberElementLightBulbProvider.cs" />
@@ -61,6 +63,7 @@
     <Compile Include="VSCustomElementPackage.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -90,6 +93,11 @@
     <Reference Include="Microsoft.VisualStudio.Editor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Program Files\Microsoft Visual Studio 14.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.0.23205\lib\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.0.23205" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Currently this depends on Microsoft.Html.Editor.SuggestedActions.HtmlSuggestedActionBase which is not a stable extensibility point. This change implements ISuggestedAction directly to avoid breaks due to changes in HtmlSuggestedActionBase.